### PR TITLE
별자리 인스턴스를 추가합니다.

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ instances = {
     'madost.one',
     'stella.place',
     'k.lapy.link',
+    'constellati.one',
 }
 
 statuses = {
@@ -39,7 +40,7 @@ statuses = {
 last_updated = datetime.datetime.now()
 
 
-def get_software(instance: str) -> (str, str):
+def get_software(instance: str) -> tuple[str, str]:
     try:
         data = httpx.get(f'https://{instance}/.well-known/nodeinfo').json()
         nodeinfo_url = data['links'][0]['href']


### PR DESCRIPTION
 - 현황판 목록에 별자리 인스턴스를 추가합니다.
 - 프로젝트가 mypy를 쓰진 않지만, 타입 힌트 넣을 때 `(str, str)` 형태로 넣으면 문제가 있어서 `tuple[str, str]`로 바꿨습니다.